### PR TITLE
Update README to include Java prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ The documentation can be found [here](https://apidocs.microsoft.com/services/par
 ## Requirements.
 
 Python 3.7+ (Expected to work with Python 3.6+)
+Java JDK 8
 
 ## Command Line
 ### Install
@@ -19,7 +20,8 @@ pip install --pre az-partner-center-cli
 
 # From Source
 git clone https://github.com/microsoft/az-partner-center-cli
-pip install azureiai
+cd az-partner-center-cli
+pip install .
 ```
 
 ## Azure Partner Center (azpc) CLI Usage


### PR DESCRIPTION
Further improvements to the README based on finds during local set up.
- Adding the Java prerequisite as it is required for not just a developer set up.
- Updating clone installation commands.