### PR TITLE
Resolve VM offer publish bug & extend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ cat manifest.yml
 
 azpc vm list
 azpc vm create --name $name --config-yml $config_yml --config-json $config_json --app-path $app_path
-azpc vm show   --name $name --config-yml $config_yml --config-json $config_json --app-path $app_path
+azpc vm show --name $name --config-yml $config_yml --config-json $config_json --app-path $app_path
 azpc vm update --name $name
+azpc vm publish --name $name --config-yml $config_yml --config-json $config_json --app-path $app_path
 # azpc vm delete --name $name
 
 azpc vm plan list   --name $name

--- a/azureiai/partner_center/cli_parser.py
+++ b/azureiai/partner_center/cli_parser.py
@@ -104,7 +104,7 @@ class CLIParser:
         self.parser.add_argument(
             self._notification_emails, type=str, required=True, help="Notification e-mails to use when publishing"
         )
-        # TODO: remove arguments when manifest is used to read listing config file
+
         self.parser.add_argument(
             self._config_json, type=str, help="Listing Configuration Json", default="listing_config.json"
         )

--- a/azureiai/partner_center/cli_parser.py
+++ b/azureiai/partner_center/cli_parser.py
@@ -104,5 +104,10 @@ class CLIParser:
         self.parser.add_argument(
             self._notification_emails, type=str, required=True, help="Notification e-mails to use when publishing"
         )
+        # TODO: remove arguments when manifest is used to read listing config file
+        self.parser.add_argument(
+            self._config_json, type=str, help="Listing Configuration Json", default="listing_config.json"
+        )
+        self.parser.add_argument(self._app_path, type=str, help="Application Root Directory", default=".")
         args = self.parser.parse_args()
         return args

--- a/azureiai/partner_center/offers/virtual_machine.py
+++ b/azureiai/partner_center/offers/virtual_machine.py
@@ -89,7 +89,16 @@ class VirtualMachine(Submission):
 
     def publish(self):
         """Publish Existing Virtual Machine offer"""
-        headers, _, url = self._prepare_request()
+        with open(Path(self.app_path).joinpath(self.json_listing_config), "r", encoding="utf8") as read_file:
+            json_config = json.load(read_file)
+        if "publisherId" not in json_config:
+            raise ValueError(f"Key: publisherId is missing from {self.app_path}/{self.json_listing_config}")
+        publisher_id = json_config["publisherId"]
+        offer_id = json_config["id"]
+
+        url = f"{URL_BASE}/{publisher_id}/offers/{offer_id}/publish?api-version=2017-10-31"
+
+        headers = {"Authorization": "Bearer " + self.get_auth(), "Content-Type": "application/json"}
 
         response = requests.post(
             url, json={"metadata": {"notification-emails": self.notification_emails}}, headers=headers
@@ -151,5 +160,5 @@ class VirtualMachineCLI(CLIParser):
         """Publish a Virtual Machine Offer"""
         args = self._add_name_notification_emails_argument()
         return VirtualMachine(
-            args.name, notification_emails=args.notification_emails, app_path=args.app_path, config_yaml=args.config_yml
+            args.name, notification_emails=args.notification_emails, app_path=args.app_path, json_listing_config=args.config_json, config_yaml=args.config_yml
         ).publish()

--- a/azureiai/partner_center/offers/virtual_machine.py
+++ b/azureiai/partner_center/offers/virtual_machine.py
@@ -160,5 +160,9 @@ class VirtualMachineCLI(CLIParser):
         """Publish a Virtual Machine Offer"""
         args = self._add_name_notification_emails_argument()
         return VirtualMachine(
-            args.name, notification_emails=args.notification_emails, app_path=args.app_path, json_listing_config=args.config_json, config_yaml=args.config_yml
+            args.name,
+            notification_emails=args.notification_emails,
+            app_path=args.app_path,
+            json_listing_config=args.config_json,
+            config_yaml=args.config_yml,
         ).publish()

--- a/tests/cli_groups_tests.py
+++ b/tests/cli_groups_tests.py
@@ -178,7 +178,7 @@ def vm_list_command(config_yml, monkeypatch):
 
 
 def vm_publish_command(config_yml, json_config, monkeypatch):
-    args = _publish_command_args(config_yml, subgroup = "vm")
+    args = _publish_command_args(config_yml, subgroup="vm")
     args["config_json"] = json_config
     args["app_path"] = "tests/sample_app"
     return args_test(monkeypatch, args)

--- a/tests/cli_groups_tests.py
+++ b/tests/cli_groups_tests.py
@@ -177,15 +177,11 @@ def vm_list_command(config_yml, monkeypatch):
     return args_test(monkeypatch, args)
 
 
-def vm_publish_command(config_yml, monkeypatch):
-    def mock_post_request(url, data="", headers="", params="", json=""):
-        return namedtuple("response", ["status_code"])(*[202])
-
-    monkeypatch.setattr(requests, "post", mock_post_request)
-
-    subgroup = "vm"
-    input_args = _publish_command_args(config_yml, subgroup)
-    args_test(monkeypatch, input_args)
+def vm_publish_command(config_yml, json_config, monkeypatch):
+    args = _publish_command_args(config_yml, subgroup = "vm")
+    args["config_json"] = json_config
+    args["app_path"] = "tests/sample_app"
+    return args_test(monkeypatch, args)
 
 
 def vm_delete_command(config_yml, monkeypatch):

--- a/tests/test_cli_group_vm.py
+++ b/tests/test_cli_group_vm.py
@@ -271,6 +271,7 @@ def test_vm_list_invalid_auth_details(config_yml, monkeypatch):
     # auth token is unable to be retreived
     vm_list_command(config_yml, monkeypatch)
 
+
 @pytest.mark.integration
 @pytest.mark.skip(reason="Need to determine how to clean up test safely")
 def test_vm_publish_success(config_yml, monkeypatch):

--- a/tests/test_cli_group_vm.py
+++ b/tests/test_cli_group_vm.py
@@ -319,6 +319,10 @@ def test_vm_publish_offer_doesnot_exist(config_yml, monkeypatch):
     # Invalid configuration to show an offer that doesnt exist
     json_listing_config = "vm_config_uncreated_offer.json"
 
+    # Confirm that the offer does not exist
+    with pytest.raises(ApiException):
+        vm_show_command(config_yml, json_listing_config, monkeypatch)
+
     # Expecting a failure as the offer does not exist
     vm_publish_command(config_yml, json_listing_config, monkeypatch)
 
@@ -327,7 +331,7 @@ def test_vm_publish_offer_doesnot_exist(config_yml, monkeypatch):
 @pytest.mark.xfail(raises=ConnectionError)
 def test_vm_publish_invalid_offer(config_yml, monkeypatch):
     # All of the required config is not set, so unable to publish offer
-    json_listing_config = "vm_config.json"
+    json_listing_config = "vm_invalid_config.json"
 
     # Expecting a failure as the offer isnt fully configured
     vm_publish_command(config_yml, json_listing_config, monkeypatch)

--- a/tests/test_cli_group_vm.py
+++ b/tests/test_cli_group_vm.py
@@ -22,6 +22,7 @@ from tests.cli_groups_tests import (
     vm_show_plan_command,
     vm_update_plan_command,
     vm_delete_plan_command,
+    vm_publish_command,
     _assert_properties,
     _assert_offer_listing,
     _assert_preview_audience,
@@ -270,6 +271,67 @@ def test_vm_list_invalid_auth_details(config_yml, monkeypatch):
     # auth token is unable to be retreived
     vm_list_command(config_yml, monkeypatch)
 
+@pytest.mark.integration
+@pytest.mark.skip(reason="Need to determine how to clean up test safely")
+def test_vm_publish_success(config_yml, monkeypatch):
+    # TODO: determine how to clean up tests so that it cancels the publish operation
+    # and can then delete the offer
+    json_listing_config = "vm_config.json"
+
+    try:
+        with pytest.raises(ApiException):
+            vm_create_command(config_yml, json_listing_config, monkeypatch)
+    except:
+        print("VM Offer already has been created")
+
+    offer_response = vm_publish_command(config_yml, json_listing_config, monkeypatch)
+
+    print(offer_response)
+
+
+@pytest.mark.integration
+@pytest.mark.xfail(raises=ValueError)
+def test_vm_publish_missing_publisher_id(config_yml, monkeypatch):
+    # Invalid JSON config with missing publisher ID
+    json_listing_config = "vm_config_missing_publisher_id.json"
+
+    # Expecting a Value error when unable to access Publisher ID
+    vm_publish_command(config_yml, json_listing_config, monkeypatch)
+
+
+@pytest.mark.integration
+@pytest.mark.xfail(raises=adal_error.AdalError)
+def test_vm_publish_invalid_auth_details(config_yml, monkeypatch):
+    # Invalid config yaml file using incorrect client ID & secret
+    config_yml = "tests/sample_app/config_invalid.yml"
+
+    # Valid JSON configuration file
+    json_listing_config = "vm_config.json"
+
+    # Expecting a failure from the Authentication Context package as the
+    # auth token is unable to be retreived
+    vm_publish_command(config_yml, json_listing_config, monkeypatch)
+
+
+@pytest.mark.integration
+@pytest.mark.xfail(raises=ConnectionError)
+def test_vm_publish_offer_doesnot_exist(config_yml, monkeypatch):
+    # Invalid configuration to show an offer that doesnt exist
+    json_listing_config = "vm_config_uncreated_offer.json"
+
+    # Expecting a failure as the offer does not exist
+    vm_publish_command(config_yml, json_listing_config, monkeypatch)
+
+
+@pytest.mark.integration
+@pytest.mark.xfail(raises=ConnectionError)
+def test_vm_publish_invalid_offer(config_yml, monkeypatch):
+    # All of the required config is not set, so unable to publish offer
+    json_listing_config = "vm_config.json"
+
+    # Expecting a failure as the offer isnt fully configured
+    vm_publish_command(config_yml, json_listing_config, monkeypatch)
+
 
 @pytest.mark.integration
 def test_vm_plan_create(config_yml, monkeypatch, app_path_fix, json_listing_config):
@@ -323,8 +385,3 @@ def test_vm_plan_delete(config_yml, monkeypatch):
 @pytest.mark.integration
 def test_vm_delete(config_yml, monkeypatch):
     vm_delete_command(config_yml, monkeypatch)
-
-
-@pytest.mark.integration
-def test_vm_publish(config_yml, monkeypatch):
-    vm_publish_command(config_yml, monkeypatch)

--- a/tests/test_cli_group_vm.py
+++ b/tests/test_cli_group_vm.py
@@ -275,8 +275,8 @@ def test_vm_list_invalid_auth_details(config_yml, monkeypatch):
 @pytest.mark.integration
 @pytest.mark.skip(reason="Need to determine how to clean up test safely")
 def test_vm_publish_success(config_yml, monkeypatch):
-    # TODO: determine how to clean up tests so that it cancels the publish operation
-    # and can then delete the offer
+    # Need to determine how to clean up tests so that it cancels the publish
+    # operation and can then delete the offer
     json_listing_config = "vm_config.json"
 
     try:

--- a/tests/test_cli_groups_mock.py
+++ b/tests/test_cli_groups_mock.py
@@ -377,7 +377,7 @@ def test_vm_list_invalid_auth_details_mock(config_yml, monkeypatch):
 
     cli_tests.vm_list_command(config_yml, monkeypatch)
 
-    
+
 def test_vm_publish_success_mock(config_yml, monkeypatch):
     vm_config_json = "vm_config.json"
 
@@ -394,7 +394,7 @@ def test_vm_publish_success_mock(config_yml, monkeypatch):
             self.status_code = 202
 
     mock_url = "https://cloudpartner.azure.com/api/publishers/contoso/offers/test-vm/publish?api-version=2017-10-31"
-    
+
     def mock_publish_offer(self, headers, url=mock_url, json={}):
         return MockResponse()
 
@@ -403,6 +403,7 @@ def test_vm_publish_success_mock(config_yml, monkeypatch):
     response = cli_tests.vm_publish_command(config_yml, vm_config_json, monkeypatch)
 
     assert json.loads(response) == True
+
 
 @pytest.mark.integration
 @pytest.mark.xfail(raises=ValueError)
@@ -425,7 +426,7 @@ def test_vm_publish_invalid_auth_details_mock(config_yml, monkeypatch):
 
     # Mock authorization token retreival to return an error
     def mock_get_auth(self, resource, client_id, client_secret):
-        raise adal_error.AdalError('Get Token request returned http error: 401 and server response: ...')
+        raise adal_error.AdalError("Get Token request returned http error: 401 and server response: ...")
 
     monkeypatch.setattr(AuthenticationContext, "acquire_token_with_client_credentials", mock_get_auth)
 

--- a/tests/test_cli_groups_mock.py
+++ b/tests/test_cli_groups_mock.py
@@ -377,9 +377,123 @@ def test_vm_list_invalid_auth_details_mock(config_yml, monkeypatch):
 
     cli_tests.vm_list_command(config_yml, monkeypatch)
 
+    
+def test_vm_publish_success_mock(config_yml, monkeypatch):
+    vm_config_json = "vm_config.json"
 
-def test_vm_publish_mock(config_yml, monkeypatch, ama_mock):
-    cli_tests.vm_publish_command(config_yml, monkeypatch)
+    # Mock authorization token retreival
+    def mock_get_auth(self, resource, client_id, client_secret):
+        return {"accessToken": "test-token"}
+
+    monkeypatch.setattr(AuthenticationContext, "acquire_token_with_client_credentials", mock_get_auth)
+
+    # Mock VM offer publish API endpoint
+    # Set up Requests mock class
+    class MockResponse:
+        def __init__(self):
+            self.status_code = 202
+
+    mock_url = "https://cloudpartner.azure.com/api/publishers/contoso/offers/test-vm/publish?api-version=2017-10-31"
+    
+    def mock_publish_offer(self, headers, url=mock_url, json={}):
+        return MockResponse()
+
+    monkeypatch.setattr(requests, "post", mock_publish_offer)
+
+    response = cli_tests.vm_publish_command(config_yml, vm_config_json, monkeypatch)
+
+    assert json.loads(response) == True
+
+@pytest.mark.integration
+@pytest.mark.xfail(raises=ValueError)
+def test_vm_publish_missing_publisher_id_mock(config_yml, monkeypatch):
+    # Invalid JSON config with missing publisher ID
+    vm_config_json = "vm_config_missing_publisher_id.json"
+
+    # No mocks required because it does not hit any APIs
+    cli_tests.vm_publish_command(config_yml, vm_config_json, monkeypatch)
+
+
+@pytest.mark.integration
+@pytest.mark.xfail(raises=adal_error.AdalError)
+def test_vm_publish_invalid_auth_details_mock(config_yml, monkeypatch):
+    # Invalid config yaml file using incorrect client ID & secret
+    config_yml = "tests/sample_app/config_invalid.yml"
+
+    # Valid JSON configuration file
+    json_listing_config = "vm_config.json"
+
+    # Mock authorization token retreival to return an error
+    def mock_get_auth(self, resource, client_id, client_secret):
+        raise adal_error.AdalError('Get Token request returned http error: 401 and server response: ...')
+
+    monkeypatch.setattr(AuthenticationContext, "acquire_token_with_client_credentials", mock_get_auth)
+
+    cli_tests.vm_publish_command(config_yml, json_listing_config, monkeypatch)
+
+
+@pytest.mark.integration
+@pytest.mark.xfail(raises=ConnectionError)
+def test_vm_publish_offer_does_not_exist_mock(config_yml, monkeypatch):
+    # Invalid configuration to show an offer that doesnt exist
+    vm_config_json = "vm_config_uncreated_offer.json"
+
+    # Mock authorization token retreival
+    def mock_get_auth(self, resource, client_id, client_secret):
+        return {"accessToken": "test-token"}
+
+    monkeypatch.setattr(AuthenticationContext, "acquire_token_with_client_credentials", mock_get_auth)
+
+    mock_url = "https://cloudpartner.azure.com/api/publishers/contoso/offers/test-vm/publish?api-version=2017-10-31"
+
+    # Mock the show VM offer API method
+    class ShowMockResponse:
+        def __init__(self):
+            self.status_code = 404
+
+        @staticmethod
+        def json():
+            return "Microsoft.Ingestion.Api.Common.Exceptions.Http404Exception..."
+
+    def mock_publish_offer(self, headers, url=mock_url, json={}):
+        return ShowMockResponse()
+
+    monkeypatch.setattr(requests, "post", mock_publish_offer)
+
+    # Expecting a failure as the offer does not exist
+    cli_tests.vm_publish_command(config_yml, vm_config_json, monkeypatch)
+
+
+@pytest.mark.integration
+@pytest.mark.xfail(raises=ConnectionError)
+def test_vm_publish_invalid_offer_mock(config_yml, monkeypatch):
+    # Invalid configuration to show an offer that doesnt exist
+    vm_config_json = "vm_config.json"
+
+    # Mock authorization token retreival
+    def mock_get_auth(self, resource, client_id, client_secret):
+        return {"accessToken": "test-token"}
+
+    monkeypatch.setattr(AuthenticationContext, "acquire_token_with_client_credentials", mock_get_auth)
+
+    mock_url = "https://cloudpartner.azure.com/api/publishers/contoso/offers/test-vm/publish?api-version=2017-10-31"
+
+    # Mock the show VM offer API method
+    class ShowMockResponse:
+        def __init__(self):
+            self.status_code = 422
+
+        @staticmethod
+        def json():
+            return "Microsoft.Ingestion.Api.Common.Exceptions.Http422Exception..."
+
+    def mock_publish_offer(self, headers, url=mock_url, json={}):
+        return ShowMockResponse()
+
+    monkeypatch.setattr(requests, "post", mock_publish_offer)
+
+    # Expecting a failure as the offer does not exist
+    cli_tests.vm_publish_command(config_yml, vm_config_json, monkeypatch)
 
 
 @pytest.mark.skip(reason="Delete functionality not yet implemented.")


### PR DESCRIPTION
There was an issue that the `azpc vm publish` command was not using the right API endpoint due to the incorrect use of the prepare request method. This pull request resolves this bug and extends the VM publishing unit and integration tests.

Note: Until the manifest is correctly used, this method needs to reference the JSON listing configuration, meaning that it
must be able to be passed into the CLI command so that the user can configure which config to use.