### PR TITLE
Pass config_yaml to plan methods

### DIFF
--- a/azureiai/partner_center/plan.py
+++ b/azureiai/partner_center/plan.py
@@ -245,6 +245,7 @@ class PlanCLIParser(CLIParser):
             return self.submission_type(
                 args.plan_name,
                 args.name,
+                config_yaml=args.config_yml,
                 json_listing_config=args.config_json,
                 app_path=args.app_path,
                 subtype=args.subgroup,
@@ -257,17 +258,17 @@ class PlanCLIParser(CLIParser):
     def list_command(self) -> {}:
         """Create a new Managed Application"""
         args = self.parser.parse_args()
-        return self.submission_type(name=args.name).list_contents()
+        return self.submission_type(name=args.name, config_yaml=args.config_yml).list_contents()
 
     def show(self) -> {}:
         """Create a new Managed Application"""
         args = self._add_name_argument()
-        return self.submission_type(args.plan_name, args.name).show()
+        return self.submission_type(args.plan_name, args.name, config_yaml=args.config_yml).show()
 
     def delete(self) -> {}:
         """Create a new Managed Application"""
         args = self._add_name_argument()
-        return self.submission_type(args.plan_name, args.name).delete()
+        return self.submission_type(args.plan_name, args.name, config_yaml=args.config_yml).delete()
 
     def update(self) -> {}:
         """Create a new Managed Application"""
@@ -278,6 +279,7 @@ class PlanCLIParser(CLIParser):
         return self.submission_type(
             args.plan_name,
             args.name,
+            config_yaml=args.config_yml,
             json_listing_config=args.config_json,
             app_path=args.app_path,
             subtype=args.subgroup,


### PR DESCRIPTION
Fixes bug where plan commands are using default config.yml rather than what's passed in via --config-yml flag.