### PR TITLE
Fix virtual machine deletion functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ azpc vm create --name $name --config-yml $config_yml --config-json $config_json 
 azpc vm show --name $name --config-yml $config_yml --config-json $config_json --app-path $app_path
 azpc vm update --name $name
 azpc vm publish --name $name --config-yml $config_yml --config-json $config_json --app-path $app_path
-# azpc vm delete --name $name
+azpc vm delete --name $name
 
 azpc vm plan list   --name $name
 azpc vm plan create --name $name --plan-name $plan_name 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ azpc vm create --name $name --config-yml $config_yml --config-json $config_json 
 azpc vm show --name $name --config-yml $config_yml --config-json $config_json --app-path $app_path
 azpc vm update --name $name
 azpc vm publish --name $name --config-yml $config_yml --config-json $config_json --app-path $app_path
-azpc vm delete --name $name
+#  azpc vm delete --name $name
 
 azpc vm plan list   --name $name
 azpc vm plan create --name $name --plan-name $plan_name 

--- a/azureiai/partner_center/offers/virtual_machine.py
+++ b/azureiai/partner_center/offers/virtual_machine.py
@@ -114,8 +114,7 @@ class VirtualMachine(Submission):
             if self._legacy_authorization is None:
                 self._legacy_authorization = f"Bearer {self._get_auth(resource)}"
             return self._legacy_authorization
-        else:
-            raise Exception("The provided resource is unsupported.")
+        raise Exception("The provided resource is unsupported.")
 
     def _get_auth(self, resource) -> str:
         with open(self.config_yaml, encoding="utf8") as file:

--- a/azureiai/partner_center/offers/virtual_machine.py
+++ b/azureiai/partner_center/offers/virtual_machine.py
@@ -119,7 +119,7 @@ class VirtualMachine(Submission):
 
     def _get_auth(self, resource) -> str:
         with open(self.config_yaml, encoding="utf8") as file:
-                settings = yaml.safe_load(file)
+            settings = yaml.safe_load(file)
 
         client_id = os.getenv(AAD_ID, settings["aad_id"])
         client_secret = os.getenv(AAD_CRED, settings["aad_secret"])

--- a/azureiai/partner_center/offers/virtual_machine.py
+++ b/azureiai/partner_center/offers/virtual_machine.py
@@ -110,7 +110,7 @@ class VirtualMachine(Submission):
                 self._authorization = f"Bearer {self._get_auth(resource)}"
             return self._authorization
 
-        elif resource == RESOURCE_CPP_API:
+        if resource == RESOURCE_CPP_API:
             if self._legacy_authorization is None:
                 self._legacy_authorization = f"Bearer {self._get_auth(resource)}"
             return self._legacy_authorization

--- a/tests/cli_groups_tests.py
+++ b/tests/cli_groups_tests.py
@@ -438,9 +438,11 @@ def _assert_technical_configuration(offer, json_listing_config):
     print("Technical Configuration: " + str(tech_configuration))
     assert tech_configuration
 
+
 def _assert_vm_show(offer, json_listing_config):
     assert offer["name"] == json_listing_config["definition"]["displayText"]
     assert offer["id"]
+
 
 def _assert_vm_offer_listing(offer, json_listing_config):
     assert offer["offerTypeId"] == json_listing_config["offerTypeId"]

--- a/tests/cli_groups_tests.py
+++ b/tests/cli_groups_tests.py
@@ -126,7 +126,9 @@ def _delete_command_args(config_yml, subgroup):
 
 
 def vm_create_command(config_yml, json_config, monkeypatch, capsys):
-    return args_test(monkeypatch, _create_command_args(config_yml, json_config, subgroup="vm"), capsys)
+    args = _create_command_args(config_yml, json_config, subgroup="vm")
+    args["name"] = "test-vm"
+    return args_test(monkeypatch, args, capsys)
 
 
 def vm_update_command(config_yml, json_config, monkeypatch, capsys):
@@ -169,6 +171,7 @@ def vm_delete_plan_command(config_yml, monkeypatch, capsys):
 
 def vm_show_command(config_yml, json_config, monkeypatch, capsys):
     args = _show_command_args(config_yml, subgroup="vm")
+    args["name"] = "test-vm"
     args["config_json"] = json_config
     args["app_path"] = APP_PATH
     return args_test(monkeypatch, args, capsys)
@@ -379,11 +382,9 @@ def _assert_offer_listing(offer, json_listing_config):
 def _assert_vm_list_all_offers(vm_list, json_listing_config):
     assert len(vm_list) >= 1
     assert vm_list[0]["offerTypeId"] == json_listing_config["offerTypeId"]
-    assert vm_list[0]["publisherId"] == json_listing_config["publisherId"]
     assert vm_list[0]["id"] == json_listing_config["id"]
     assert vm_list[0]["definition"]["displayText"] == json_listing_config["definition"]["displayText"]
     assert vm_list[1]["offerTypeId"] == json_listing_config["offerTypeId"]
-    assert vm_list[1]["publisherId"] == json_listing_config["publisherId"]
 
 
 def _assert_vm_offer_listing_integration(vm_list):
@@ -437,6 +438,9 @@ def _assert_technical_configuration(offer, json_listing_config):
     print("Technical Configuration: " + str(tech_configuration))
     assert tech_configuration
 
+def _assert_vm_show(offer, json_listing_config):
+    assert offer["name"] == json_listing_config["definition"]["displayText"]
+    assert offer["id"]
 
 def _assert_vm_offer_listing(offer, json_listing_config):
     assert offer["offerTypeId"] == json_listing_config["offerTypeId"]

--- a/tests/cli_groups_tests.py
+++ b/tests/cli_groups_tests.py
@@ -179,11 +179,13 @@ def vm_show_command(config_yml, json_config, monkeypatch, capsys):
 
 def vm_list_command(config_yml, monkeypatch, capsys):
     args = _list_command_args(config_yml, subgroup="vm")
+    args["name"] = "test-vm"
     return args_test(monkeypatch, args, capsys)
 
 
 def vm_publish_command(config_yml, json_config, monkeypatch, capsys):
     args = _publish_command_args(config_yml, subgroup="vm")
+    args["name"] = "test-vm"
     args["config_json"] = json_config
     args["app_path"] = APP_PATH
     return args_test(monkeypatch, args, capsys)
@@ -192,6 +194,7 @@ def vm_publish_command(config_yml, json_config, monkeypatch, capsys):
 def vm_delete_command(config_yml, monkeypatch, capsys):
     subgroup = "vm"
     input_args = _delete_command_args(config_yml, subgroup)
+    input_args["name"] = "test-vm"
     args_test(monkeypatch, input_args, capsys)
 
 

--- a/tests/sample_app/vm_config.json
+++ b/tests/sample_app/vm_config.json
@@ -1,13 +1,13 @@
 {
   "publisherId": "contoso",
   "offerTypeId": "microsoft-azure-virtualmachines",
-  "id": "test-vm",
+  "id": "test_vm",
   "offerTypeVersions": {
       "microsoft-azure-virtualmachines": 87,
       "microsoft-azure-marketplace": 39
   },
   "definition": {
-      "displayText": "Test Virtual Machine Offer",
+      "displayText": "test_vm",
       "offer": {
       "microsoft-azure-marketplace.title": "Contoso App",
       "microsoft-azure-marketplace.summary": "Contoso App makes dev ops a breeze",

--- a/tests/sample_app/vm_invalid_config.json
+++ b/tests/sample_app/vm_invalid_config.json
@@ -34,21 +34,11 @@
               ]
           }
       ],
-      "microsoft-azure-marketplace.smallLogo": "https://github.com/alexandrakoller/test_logos/blob/main/image_48_48_small.png",
-      "microsoft-azure-marketplace.mediumLogo": "https://github.com/alexandrakoller/test_logos/blob/main/image_90_90_medium.png",
-      "microsoft-azure-marketplace.largeLogo": "https://github.com/alexandrakoller/test_logos/blob/main/image_216_216_large.png",
-      "microsoft-azure-marketplace.wideLogo": "https://github.com/alexandrakoller/test_logos/blob/main/image_255_115_wide.png",
       "microsoft-azure-marketplace.screenshots": [],
       "microsoft-azure-marketplace.videos": [],
       "microsoft-azure-marketplace.leadDestination": "None",
       "microsoft-azure-marketplace.privacyURL": "https://azuremarketplace.microsoft.com",
       "microsoft-azure-marketplace.termsOfUse": "Terms of use",
-      "microsoft-azure-marketplace.engineeringContactName": "Jon Doe",
-      "microsoft-azure-marketplace.engineeringContactEmail": "jondoe@outlook.com",
-      "microsoft-azure-marketplace.engineeringContactPhone": "555-555-5555",
-      "microsoft-azure-marketplace.supportContactName": "Jon Doe",
-      "microsoft-azure-marketplace.supportContactEmail": "jondoe@outlook.com",
-      "microsoft-azure-marketplace.supportContactPhone": "555-555-5555",
       "microsoft-azure-marketplace.publicAzureSupportUrl": "",
       "microsoft-azure-marketplace.fairfaxSupportUrl": ""
   },

--- a/tests/test_cli_group_vm.py
+++ b/tests/test_cli_group_vm.py
@@ -339,6 +339,36 @@ def test_vm_publish_invalid_offer(config_yml, monkeypatch, capsys):
 
 
 @pytest.mark.integration
+def test_vm_delete_success(config_yml, monkeypatch, capsys):
+    json_listing_config = "vm_config.json"
+    try:
+        with pytest.raises(ApiException):
+            vm_create_command(config_yml, json_listing_config, monkeypatch, capsys)
+    except:
+        print("VM Offer already has been created")
+
+    vm_delete_command(config_yml, monkeypatch)
+
+    # Confirm that the offer has been deleted
+    with pytest.raises(LookupError):
+        vm_show_command(config_yml, json_listing_config, monkeypatch, capsys)
+
+
+@pytest.mark.integration
+@pytest.mark.xfail(raises=LookupError)
+def test_vm_delete_offer_doesnot_exist(config_yml, monkeypatch, capsys):
+    vm_delete_command(config_yml, monkeypatch, capsys)
+
+
+@pytest.mark.integration
+@pytest.mark.xfail(raises=adal_error.AdalError)
+def test_vm_delete_invalid_auth_details(config_yml, monkeypatch, capsys):
+    # Invalid config yaml file using incorrect client ID & secret
+    config_yml = "tests/sample_app/config_invalid.yml"
+    vm_delete_command(config_yml, monkeypatch, capsys)
+
+
+@pytest.mark.integration
 def test_vm_plan_create(config_yml, monkeypatch, app_path_fix, json_listing_config, capsys):
     try:
         vm_show_plan_command(config_yml, monkeypatch, capsys)
@@ -385,8 +415,3 @@ def test_vm_plan_list(config_yml, monkeypatch, capsys):
 @pytest.mark.integration
 def test_vm_plan_delete(config_yml, monkeypatch, capsys):
     vm_delete_plan_command(config_yml, monkeypatch, capsys)
-
-
-@pytest.mark.integration
-def test_vm_delete(config_yml, monkeypatch, capsys):
-    vm_delete_command(config_yml, monkeypatch, capsys)

--- a/tests/test_cli_group_vm.py
+++ b/tests/test_cli_group_vm.py
@@ -29,6 +29,7 @@ from tests.cli_groups_tests import (
     _assert_pricing_and_availability,
     _assert_technical_configuration,
     _assert_plan_listing,
+    _assert_vm_show,
     _assert_vm_properties,
     _assert_vm_offer_listing,
     _assert_vm_preview_audience,
@@ -200,10 +201,7 @@ def test_vm_show_success(config_yml, monkeypatch, capsys):
     with open(Path(app_path_fix).joinpath(json_listing_config), "r", encoding="utf8") as read_file:
         json_config = json.load(read_file)
 
-    _assert_vm_properties(offer_listing, json_config, 1)
-    _assert_vm_offer_listing(offer_listing, json_config)
-    _assert_vm_preview_audience(offer_listing, json_config)
-    _assert_vm_plan_listing(offer_listing, json_config)
+    _assert_vm_show(offer_listing, json_config)
 
 
 @pytest.mark.integration
@@ -231,7 +229,7 @@ def test_vm_show_invalid_auth_details(config_yml, monkeypatch, capsys):
 
 
 @pytest.mark.integration
-@pytest.mark.xfail(raises=ConnectionError)
+@pytest.mark.xfail(raises=LookupError)
 def test_vm_show_invalid_offer(config_yml, monkeypatch, capsys):
     # Invalid configuration to show an offer that doesnt exist
     json_listing_config = "vm_config_uncreated_offer.json"
@@ -321,7 +319,7 @@ def test_vm_publish_offer_doesnot_exist(config_yml, monkeypatch, capsys):
     json_listing_config = "vm_config_uncreated_offer.json"
 
     # Confirm that the offer does not exist
-    with pytest.raises(ApiException):
+    with pytest.raises(LookupError):
         vm_show_command(config_yml, json_listing_config, monkeypatch, capsys)
 
     # Expecting a failure as the offer does not exist

--- a/tests/test_cli_groups_mock.py
+++ b/tests/test_cli_groups_mock.py
@@ -494,7 +494,7 @@ def test_vm_delete_success_mock(config_yml, monkeypatch, capsys):
 
     # Mock VM offer delete API endpoint
     def mock_delete_product(self, product_id, authorization, **kwargs):
-        return ''
+        return ""
 
     monkeypatch.setattr(ProductApi, "products_product_id_delete", mock_delete_product)
     cli_tests.vm_delete_command(config_yml, monkeypatch, capsys)

--- a/tests/test_data/vm_create_valid_response.json
+++ b/tests/test_data/vm_create_valid_response.json
@@ -1,0 +1,147 @@
+{
+    "offerTypeId": "microsoft-azure-virtualmachines",
+    "publisherId": "test-publisher",
+    "status": "waitingForPublisherReview",
+    "pcMigrationStatus": "migrated",
+    "pcRedirectUri": "",
+    "isvUpgradeRequest": false,
+    "version": 1252868275,
+    "id": "test-vm",
+    "definition": {
+        "displayText": "test-vm",
+        "offer": {
+            "microsoft-azure-marketplace.leadDestination": "None",
+            "microsoft-azure-marketplace.blobLeadConfiguration": {},
+            "microsoft-azure-marketplace.crmLeadConfiguration": {},
+            "microsoft-azure-marketplace.httpsEndpointLeadConfiguration": {},
+            "microsoft-azure-marketplace.marketoLeadConfiguration": {},
+            "microsoft-azure-marketplace.salesForceLeadConfiguration": {},
+            "microsoft-azure-marketplace.tableLeadConfiguration": {},
+            "microsoft-azure-marketplace.leadNotificationEmails": "",
+            "microsoft-azure-marketplace-testdrive.enabled": false,
+            "microsoft-azure-marketplace.useEnterpriseContract": false,
+            "microsoft-azure-marketplace.termsOfUse": "Terms of use",
+            "microsoft-azure-marketplace.universalAmendmentTerms": "",
+            "microsoft-azure-marketplace.customAmendments": null,
+            "microsoft-azure-marketplace.categories": [],
+            "microsoft-azure-marketplace.categoryMap": [
+                {
+                    "categoryL1": "analytics",
+                    "categoryL2-analytics": [
+                        "visualization-and-reporting"
+                    ]
+                },
+                {
+                    "categoryL1": "ai-plus-machine-learning",
+                    "categoryL2-ai-plus-machine-learning": [
+                        "bot-services",
+                        "cognitive-services"
+                    ]
+                }
+            ],
+            "microsoft-azure-marketplace.allowedSubscriptions": [
+                "d2b43582-c056-4b5a-a992-7230ffa51e8d"
+            ],
+            "microsoft-azure-marketplace.title": "Contoso App",
+            "microsoft-azure-marketplace.offerMarketingUrlIdentifier": "contosoapp",
+            "microsoft-azure-marketplace.summary": "Contoso App makes dev ops a breeze",
+            "microsoft-azure-marketplace.longSummary": "Contoso App makes dev ops a breeze",
+            "microsoft-azure-marketplace.description": "Contoso App makes dev ops a breeze",
+            "microsoft-azure-marketplace.privacyURL": "https://azuremarketplace.microsoft.com",
+            "microsoft-azure-marketplace.fairfaxSupportUrl": "",
+            "microsoft-azure-marketplace.publicAzureSupportUrl": "",
+            "microsoft-azure-marketplace.engineeringContactName": "Jon Doe",
+            "microsoft-azure-marketplace.engineeringContactEmail": "jondoe@outlook.com",
+            "microsoft-azure-marketplace.engineeringContactPhone": "555-555-5555",
+            "microsoft-azure-marketplace.supportContactName": "Jon Doe",
+            "microsoft-azure-marketplace.supportContactEmail": "jondoe@outlook.com",
+            "microsoft-azure-marketplace.supportContactPhone": "555-555-5555",
+            "microsoft-azure-marketplace.usefulLinks": [
+                {
+                    "linkTitle": "Contoso App for Azure",
+                    "linkUrl": "https://azuremarketplace.microsoft.com"
+                }
+            ],
+            "microsoft-azure-marketplace.smallLogo": "testURI.com",
+            "microsoft-azure-marketplace.mediumLogo": "testURI.com",
+            "microsoft-azure-marketplace.largeLogo": "testURI.com",
+            "microsoft-azure-marketplace.wideLogo": "testURI.com",
+            "microsoft-azure-marketplace.screenshots": [],
+            "microsoft-azure-marketplace.videos": [],
+            "microsoft-azure-marketplace-testdrive.description": null,
+            "microsoft-azure-marketplace-testdrive.accessInformation": null,
+            "microsoft-azure-marketplace-testdrive.videos": [],
+            "microsoft-azure-marketplace-testdrive.userManual": "",
+            "microsoft-azure-virtualmachines.managerContactName": "",
+            "microsoft-azure-virtualmachines.managerContactEmail": "",
+            "microsoft-azure-virtualmachines.managerContactPhone": "",
+            "microsoft-azure-virtualmachines.gtmMaterials": ""
+        },
+        "plans": [
+            {
+                "planId": "contososkuidentifier",
+                "microsoft-azure-virtualmachines.cloudAvailability": [
+                    "PublicAzure"
+                ],
+                "microsoft-azure-virtualmachines.certificationsFairfax": [],
+                "microsoft-azure-virtualmachines.legacyPlanId": "contososkuidentifier",
+                "microsoft-azure-virtualmachines.hideSKUForSolutionTemplate": false,
+                "virtualMachinePricingV2": {
+                    "isByol": false,
+                    "coreMultiplier": {
+                        "currency": "USD",
+                        "single": 0
+                    },
+                    "freeTrialDurationInMonths": 0
+                },
+                "regions": [
+                    "AZ"
+                ],
+                "virtualMachinePricing": {
+                    "isByol": false,
+                    "coreMultiplier": {
+                        "currency": "USD",
+                        "single": 0
+                    },
+                    "freeTrialDurationInMonths": 0
+                },
+                "microsoft-azure-virtualmachines.openPorts": [],
+                "microsoft-azure-virtualmachines.operatingSystemFamily": "Windows",
+                "microsoft-azure-virtualmachines.operationSystem": "Contoso App",
+                "microsoft-azure-virtualmachines.osType": "Other",
+                "microsoft-azure-virtualmachines.recommendedVMSizes": [
+                    "a0-basic",
+                    "a0-standard",
+                    "a1-basic",
+                    "a1-standard",
+                    "a2-basic",
+                    "a2-standard"
+                ],
+                "microsoft-azure-virtualmachines.supportsAcceleratedNetworking": false,
+                "microsoft-azure-virtualmachines.supportsCloudInit": false,
+                "microsoft-azure-virtualmachines.supportsBackup": false,
+                "microsoft-azure-virtualmachines.isNetworkVirtualAppliance": false,
+                "microsoft-azure-virtualmachines.isLockedDown": false,
+                "microsoft-azure-virtualmachines.isCustomArmTemplateRequired": false,
+                "microsoft-azure-virtualmachines.supportsExtensions": true,
+                "microsoft-azure-virtualmachines.supportsHibernation": false,
+                "microsoft-azure-virtualmachines.supportsNVMe": false,
+                "microsoft-azure-virtualmachines.generation": "1",
+                "microsoft-azure-virtualmachines.allowOnlyManagedDiskDeployments": true,
+                "microsoft-azure-virtualmachines.patchOptions": {
+                    "supportsHotpatch": false
+                },
+                "microsoft-azure-virtualmachines.vmImages": {
+                    "1.0.1": {
+                        "osVhdUrl": "",
+                        "lunVhdDetails": []
+                    }
+                },
+                "microsoft-azure-virtualmachines.skuTitle": "Contoso App",
+                "microsoft-azure-virtualmachines.skuSummary": "Contoso App makes dev ops a breeze.",
+                "microsoft-azure-virtualmachines.skuDescription": "This is a description for the Contoso App that makes dev ops a breeze."
+            }
+        ]
+    },
+    "changedTime": "2022-06-01T05:41:25.9695742Z"
+}

--- a/tests/test_data/vm_list_valid_response.json
+++ b/tests/test_data/vm_list_valid_response.json
@@ -13,7 +13,7 @@
         "version": 0,
         "id": "test-vm",
         "definition": {
-            "displayText": "Test Virtual Machine Offer"
+            "displayText": "test-vm"
         },
         "changedTime": "2022-06-02T12:25:56.651"
     },

--- a/tests/test_data/vm_show_offer_not_found_response.json
+++ b/tests/test_data/vm_show_offer_not_found_response.json
@@ -1,8 +1,3 @@
 {
-    "Product": {
-        "serviceName": "Product",
-        "error": "Microsoft.Ingestion.Api.Common.Exceptions.Http404Exception: CPP product test-offer not found in current PC environment.",
-        "exceptionCode": "Http404Exception",
-        "httpStatusCode": "NotFound"
-    }
+    "value": []
 }

--- a/tests/test_data/vm_show_valid_response.json
+++ b/tests/test_data/vm_show_valid_response.json
@@ -2,15 +2,15 @@
     "value": [
         {
             "resourceType": "AzureThirdPartyVirtualMachine",
-            "name": "test_vm",
+            "name": "test-vm",
             "externalIDs": [
                 {
                     "type": "AzureOfferId",
-                    "value": "test_vm"
+                    "value": "test-vm"
                 }
             ],
             "isModularPublishing": true,
-            "id": ""
+            "id": "abc123"
         }
     ]
 }

--- a/tests/test_data/vm_show_valid_response.json
+++ b/tests/test_data/vm_show_valid_response.json
@@ -1,147 +1,16 @@
 {
-    "offerTypeId": "microsoft-azure-virtualmachines",
-    "publisherId": "test-publisher",
-    "status": "waitingForPublisherReview",
-    "pcMigrationStatus": "migrated",
-    "pcRedirectUri": "",
-    "isvUpgradeRequest": false,
-    "version": 1252868275,
-    "id": "test-vm",
-    "definition": {
-        "displayText": "Test Virtual Machine Offer",
-        "offer": {
-            "microsoft-azure-marketplace.leadDestination": "None",
-            "microsoft-azure-marketplace.blobLeadConfiguration": {},
-            "microsoft-azure-marketplace.crmLeadConfiguration": {},
-            "microsoft-azure-marketplace.httpsEndpointLeadConfiguration": {},
-            "microsoft-azure-marketplace.marketoLeadConfiguration": {},
-            "microsoft-azure-marketplace.salesForceLeadConfiguration": {},
-            "microsoft-azure-marketplace.tableLeadConfiguration": {},
-            "microsoft-azure-marketplace.leadNotificationEmails": "",
-            "microsoft-azure-marketplace-testdrive.enabled": false,
-            "microsoft-azure-marketplace.useEnterpriseContract": false,
-            "microsoft-azure-marketplace.termsOfUse": "Terms of use",
-            "microsoft-azure-marketplace.universalAmendmentTerms": "",
-            "microsoft-azure-marketplace.customAmendments": null,
-            "microsoft-azure-marketplace.categories": [],
-            "microsoft-azure-marketplace.categoryMap": [
+    "value": [
+        {
+            "resourceType": "AzureThirdPartyVirtualMachine",
+            "name": "test_vm",
+            "externalIDs": [
                 {
-                    "categoryL1": "analytics",
-                    "categoryL2-analytics": [
-                        "visualization-and-reporting"
-                    ]
-                },
-                {
-                    "categoryL1": "ai-plus-machine-learning",
-                    "categoryL2-ai-plus-machine-learning": [
-                        "bot-services",
-                        "cognitive-services"
-                    ]
+                    "type": "AzureOfferId",
+                    "value": "test_vm"
                 }
             ],
-            "microsoft-azure-marketplace.allowedSubscriptions": [
-                "d2b43582-c056-4b5a-a992-7230ffa51e8d"
-            ],
-            "microsoft-azure-marketplace.title": "Contoso App",
-            "microsoft-azure-marketplace.offerMarketingUrlIdentifier": "contosoapp",
-            "microsoft-azure-marketplace.summary": "Contoso App makes dev ops a breeze",
-            "microsoft-azure-marketplace.longSummary": "Contoso App makes dev ops a breeze",
-            "microsoft-azure-marketplace.description": "Contoso App makes dev ops a breeze",
-            "microsoft-azure-marketplace.privacyURL": "https://azuremarketplace.microsoft.com",
-            "microsoft-azure-marketplace.fairfaxSupportUrl": "",
-            "microsoft-azure-marketplace.publicAzureSupportUrl": "",
-            "microsoft-azure-marketplace.engineeringContactName": "Jon Doe",
-            "microsoft-azure-marketplace.engineeringContactEmail": "jondoe@outlook.com",
-            "microsoft-azure-marketplace.engineeringContactPhone": "555-555-5555",
-            "microsoft-azure-marketplace.supportContactName": "Jon Doe",
-            "microsoft-azure-marketplace.supportContactEmail": "jondoe@outlook.com",
-            "microsoft-azure-marketplace.supportContactPhone": "555-555-5555",
-            "microsoft-azure-marketplace.usefulLinks": [
-                {
-                    "linkTitle": "Contoso App for Azure",
-                    "linkUrl": "https://azuremarketplace.microsoft.com"
-                }
-            ],
-            "microsoft-azure-marketplace.smallLogo": "testURI.com",
-            "microsoft-azure-marketplace.mediumLogo": "testURI.com",
-            "microsoft-azure-marketplace.largeLogo": "testURI.com",
-            "microsoft-azure-marketplace.wideLogo": "testURI.com",
-            "microsoft-azure-marketplace.screenshots": [],
-            "microsoft-azure-marketplace.videos": [],
-            "microsoft-azure-marketplace-testdrive.description": null,
-            "microsoft-azure-marketplace-testdrive.accessInformation": null,
-            "microsoft-azure-marketplace-testdrive.videos": [],
-            "microsoft-azure-marketplace-testdrive.userManual": "",
-            "microsoft-azure-virtualmachines.managerContactName": "",
-            "microsoft-azure-virtualmachines.managerContactEmail": "",
-            "microsoft-azure-virtualmachines.managerContactPhone": "",
-            "microsoft-azure-virtualmachines.gtmMaterials": ""
-        },
-        "plans": [
-            {
-                "planId": "contososkuidentifier",
-                "microsoft-azure-virtualmachines.cloudAvailability": [
-                    "PublicAzure"
-                ],
-                "microsoft-azure-virtualmachines.certificationsFairfax": [],
-                "microsoft-azure-virtualmachines.legacyPlanId": "contososkuidentifier",
-                "microsoft-azure-virtualmachines.hideSKUForSolutionTemplate": false,
-                "virtualMachinePricingV2": {
-                    "isByol": false,
-                    "coreMultiplier": {
-                        "currency": "USD",
-                        "single": 0
-                    },
-                    "freeTrialDurationInMonths": 0
-                },
-                "regions": [
-                    "AZ"
-                ],
-                "virtualMachinePricing": {
-                    "isByol": false,
-                    "coreMultiplier": {
-                        "currency": "USD",
-                        "single": 0
-                    },
-                    "freeTrialDurationInMonths": 0
-                },
-                "microsoft-azure-virtualmachines.openPorts": [],
-                "microsoft-azure-virtualmachines.operatingSystemFamily": "Windows",
-                "microsoft-azure-virtualmachines.operationSystem": "Contoso App",
-                "microsoft-azure-virtualmachines.osType": "Other",
-                "microsoft-azure-virtualmachines.recommendedVMSizes": [
-                    "a0-basic",
-                    "a0-standard",
-                    "a1-basic",
-                    "a1-standard",
-                    "a2-basic",
-                    "a2-standard"
-                ],
-                "microsoft-azure-virtualmachines.supportsAcceleratedNetworking": false,
-                "microsoft-azure-virtualmachines.supportsCloudInit": false,
-                "microsoft-azure-virtualmachines.supportsBackup": false,
-                "microsoft-azure-virtualmachines.isNetworkVirtualAppliance": false,
-                "microsoft-azure-virtualmachines.isLockedDown": false,
-                "microsoft-azure-virtualmachines.isCustomArmTemplateRequired": false,
-                "microsoft-azure-virtualmachines.supportsExtensions": true,
-                "microsoft-azure-virtualmachines.supportsHibernation": false,
-                "microsoft-azure-virtualmachines.supportsNVMe": false,
-                "microsoft-azure-virtualmachines.generation": "1",
-                "microsoft-azure-virtualmachines.allowOnlyManagedDiskDeployments": true,
-                "microsoft-azure-virtualmachines.patchOptions": {
-                    "supportsHotpatch": false
-                },
-                "microsoft-azure-virtualmachines.vmImages": {
-                    "1.0.1": {
-                        "osVhdUrl": "",
-                        "lunVhdDetails": []
-                    }
-                },
-                "microsoft-azure-virtualmachines.skuTitle": "Contoso App",
-                "microsoft-azure-virtualmachines.skuSummary": "Contoso App makes dev ops a breeze.",
-                "microsoft-azure-virtualmachines.skuDescription": "This is a description for the Contoso App that makes dev ops a breeze."
-            }
-        ]
-    },
-    "changedTime": "2022-06-01T05:41:25.9695742Z"
+            "isModularPublishing": true,
+            "id": ""
+        }
+    ]
 }


### PR DESCRIPTION
Enabling VM offer deletion to the CLI commands.

**Design justification**
To enable VM offer deletion, there is no Cloud Partner Portal API endpoint, so we must use the Partner Center API endpoint.
To reduce the duplication of code, it made sense to use the inherited super Submission class' delete method, as functionally it is the same.
To be able to do this, the get_auth method in the VM class needed updating to be able to save the state of the CPP API and PC API auth tokens, to prevent the authentication API methods calling more than required.
The show method has been removed from the VM class and now will also use the inherited show method from the Submission class. This decision was made because the product_id is set in the Submission.show() method, which is required for deletion.