### PR TITLE
Tidy up integration tests to delete created VM offers

### DIFF
--- a/tests/cli_groups_tests.py
+++ b/tests/cli_groups_tests.py
@@ -335,7 +335,6 @@ def args_test(monkeypatch, input_args, capsys):
     azpc_app.main()
     captured = capsys.readouterr()
     assert captured.out
-    print(captured.out)
     return captured.out
 
 

--- a/tests/test_cli_group_vm.py
+++ b/tests/test_cli_group_vm.py
@@ -40,6 +40,24 @@ from tests.cli_groups_tests import (
 )
 
 
+@pytest.fixture()
+def vm_offer_setup(config_yml, monkeypatch, capsys):
+    json_listing_config = "vm_config.json"
+    vm_create_command(config_yml, json_listing_config, monkeypatch, capsys)
+    yield
+
+
+@pytest.fixture()
+def vm_offer_teardown(config_yml, monkeypatch, capsys):
+    yield
+    vm_delete_command(config_yml, monkeypatch, capsys)
+
+
+@pytest.fixture()
+def vm_offer_setup_teardown(vm_offer_setup, vm_offer_teardown):
+    return
+
+
 @pytest.mark.integration
 def test_vm_get(config_yml, monkeypatch, app_path_fix):
     with open(Path(app_path_fix).joinpath("vm_listing_config.json"), "r", encoding="utf8") as read_file:
@@ -141,7 +159,7 @@ def test_vm_list(config_yml, monkeypatch, capsys):
 
 
 @pytest.mark.integration
-def test_vm_create_success(config_yml, monkeypatch, app_path_fix, json_listing_config, capsys):
+def test_vm_create_success(config_yml, monkeypatch, app_path_fix, json_listing_config, vm_offer_teardown, capsys):
     json_listing_config = "vm_config.json"
     app_path_fix = "tests/sample_app"
 
@@ -183,15 +201,10 @@ def test_vm_create_invalid_offer(config_yml, monkeypatch, capsys):
 
 
 @pytest.mark.integration
-# This test depends on 'test_vm_create'
-def test_vm_show_success(config_yml, monkeypatch, capsys):
+def test_vm_show_success(config_yml, vm_offer_setup_teardown, monkeypatch, capsys):
     json_listing_config = "vm_config.json"
     app_path_fix = "tests/sample_app"
-    try:
-        with pytest.raises(ApiException):
-            vm_create_command(config_yml, json_listing_config, monkeypatch, capsys)
-    except:
-        print("VM Offer already has been created")
+
     offer_response = vm_show_command(config_yml, json_listing_config, monkeypatch, capsys)
 
     # Load API JSON response
@@ -202,16 +215,6 @@ def test_vm_show_success(config_yml, monkeypatch, capsys):
         json_config = json.load(read_file)
 
     _assert_vm_show(offer_listing, json_config)
-
-
-@pytest.mark.integration
-@pytest.mark.xfail(raises=ValueError)
-def test_vm_show_missing_publisher_id(config_yml, monkeypatch, capsys):
-    # Invalid JSON config with missing publisher ID
-    json_listing_config = "vm_config_missing_publisher_id.json"
-
-    # Expecting a Value error when unable to access Publisher ID
-    vm_show_command(config_yml, json_listing_config, monkeypatch, capsys)
 
 
 @pytest.mark.integration
@@ -239,15 +242,9 @@ def test_vm_show_invalid_offer(config_yml, monkeypatch, capsys):
 
 
 @pytest.mark.integration
-def test_vm_list_success(config_yml, monkeypatch, capsys):
-    json_listing_config = "vm_config.json"
-    try:
-        with pytest.raises(ApiException):
-            vm_create_command(config_yml, json_listing_config, monkeypatch, capsys)
-    except:
-        print("VM Offer already has been created")
-
+def test_vm_list_success(config_yml, vm_offer_setup_teardown, monkeypatch, capsys):
     offer_response = vm_list_command(config_yml, monkeypatch, capsys)
+
     # Load API JSON response
     vm_offer_listing = json.loads(offer_response)
     _assert_vm_offer_listing_integration(vm_offer_listing)
@@ -272,16 +269,10 @@ def test_vm_list_invalid_auth_details(config_yml, monkeypatch, capsys):
 
 @pytest.mark.integration
 @pytest.mark.skip(reason="Need to determine how to clean up test safely")
-def test_vm_publish_success(config_yml, monkeypatch, capsys):
+def test_vm_publish_success(config_yml, vm_offer_setup_teardown, monkeypatch, capsys):
     # Need to determine how to clean up tests so that it cancels the publish
     # operation and can then delete the offer
     json_listing_config = "vm_config.json"
-
-    try:
-        with pytest.raises(ApiException):
-            vm_create_command(config_yml, json_listing_config, monkeypatch, capsys)
-    except:
-        print("VM Offer already has been created")
 
     offer_response = vm_publish_command(config_yml, json_listing_config, monkeypatch, capsys)
 
@@ -337,13 +328,8 @@ def test_vm_publish_invalid_offer(config_yml, monkeypatch, capsys):
 
 
 @pytest.mark.integration
-def test_vm_delete_success(config_yml, monkeypatch, capsys):
+def test_vm_delete_success(config_yml, vm_offer_setup, monkeypatch, capsys):
     json_listing_config = "vm_config.json"
-    try:
-        with pytest.raises(ApiException):
-            vm_create_command(config_yml, json_listing_config, monkeypatch, capsys)
-    except:
-        print("VM Offer already has been created")
 
     vm_delete_command(config_yml, monkeypatch)
 


### PR DESCRIPTION
The integration tests required set up of a VM offer to validate that it was behaving as expected. Now, we are also able to delete the offers once the test has been completed.
The set up and tear down functions have been moved into a pytest fixture. The methods have been modularised so that it can be used for the create and delete integration tests.