### PR TITLE
Emilve/fix private public plan set

### DIFF
--- a/azureiai/managed_apps/confs/variant/feature_availability.py
+++ b/azureiai/managed_apps/confs/variant/feature_availability.py
@@ -79,7 +79,7 @@ class FeatureAvailability(VariantPlanConfiguration):
                 "@odata.etag": odata_etag,
                 "id": settings_id,
             }
-            
+
         if visibility == "Private":
             body["subscriptionAudiences"] = azure_subscription
 

--- a/azureiai/managed_apps/confs/variant/feature_availability.py
+++ b/azureiai/managed_apps/confs/variant/feature_availability.py
@@ -36,7 +36,7 @@ class FeatureAvailability(VariantPlanConfiguration):
     def set(
         self,
         azure_subscription,
-        visibility="Public",
+        visibility="Private",
     ):
         """Set Availability for Application
 
@@ -55,7 +55,6 @@ class FeatureAvailability(VariantPlanConfiguration):
                 "resourceType": "FeatureAvailability",
                 "visibility": visibility,
                 "marketStates": market_states,
-                "subscriptionAudiences": azure_subscription,
                 "@odata.etag": odata_etag,
                 "id": settings_id,
                 "priceSchedules": [
@@ -77,10 +76,12 @@ class FeatureAvailability(VariantPlanConfiguration):
             body = {
                 "resourceType": "FeatureAvailability",
                 "visibility": visibility,
-                "subscriptionAudiences": azure_subscription,
                 "@odata.etag": odata_etag,
                 "id": settings_id,
             }
+            
+        if visibility == "Private":
+            body["subscriptionAudiences"] = azure_subscription
 
         self.fa_api.products_product_id_featureavailabilities_feature_availability_id_put(
             authorization=self.authorization,

--- a/azureiai/partner_center/plan.py
+++ b/azureiai/partner_center/plan.py
@@ -74,7 +74,7 @@ class Plan(Submission):
             self.show()
 
         self._update_plan_listing()
-        #  self._update_pricing_and_availability() # TODO: Fix issue causing all offers to be private
+        self._update_pricing_and_availability()
         self._update_technical_configuration()
         return self._ids["product_id"]
 

--- a/schema_listing_config.json
+++ b/schema_listing_config.json
@@ -144,8 +144,8 @@
                   "visibility"                 : {
                     "type": "string",
                     "enum": [
-                      "private",
-                      "public"
+                      "Private",
+                      "Public"
                     ]
                   },
                   "azure_private_subscriptions": {

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ SWAGGER_JSON = "Partner_Ingestion_SwaggerDocument.json"
 generate_swagger(SWAGGER_JSON)
 
 NAME = "az-partner-center-cli"
-VERSION = "0.0.35"
+VERSION = "0.0.36"
 
 REQUIRES = [
     "azure-mgmt-deploymentmanager",


### PR DESCRIPTION
- Updated feature_availability.py to only set subscriptionAudiences if visibility is Private.
- Fixed visibility enum to upper-case Private/Public to match swagger def