### PR TITLE
Simplifying the VM publish command

### DIFF
--- a/azureiai/partner_center/cli_parser.py
+++ b/azureiai/partner_center/cli_parser.py
@@ -105,9 +105,5 @@ class CLIParser:
             self._notification_emails, type=str, required=True, help="Notification e-mails to use when publishing"
         )
 
-        self.parser.add_argument(
-            self._config_json, type=str, help="Listing Configuration Json", default="listing_config.json"
-        )
-        self.parser.add_argument(self._app_path, type=str, help="Application Root Directory", default=".")
         args = self.parser.parse_args()
         return args

--- a/azureiai/partner_center/offers/virtual_machine.py
+++ b/azureiai/partner_center/offers/virtual_machine.py
@@ -81,15 +81,14 @@ class VirtualMachine(Submission):
 
     def publish(self):
         """Publish Existing Virtual Machine offer"""
-        with open(Path(self.app_path).joinpath(self.json_listing_config), "r", encoding="utf8") as read_file:
-            json_config = json.load(read_file)
-        if "publisherId" not in json_config:
-            raise ValueError(f"Key: publisherId is missing from {self.app_path}/{self.json_listing_config}")
-        publisher_id = json_config["publisherId"]
-        offer_id = json_config["id"]
+        with open(self.config_yaml, encoding="utf8") as file:
+            settings = yaml.safe_load(file)
+            if "publisherId" not in settings:
+                raise ValueError(f"Key: publisherId is missing from {self.config_yaml}")
+            publisher_id = settings["publisherId"]
 
+        offer_id = self.name
         url = f"{URL_BASE}/{publisher_id}/offers/{offer_id}/publish?api-version=2017-10-31"
-
         headers = {"Authorization": self.get_auth(RESOURCE_CPP_API), "Content-Type": "application/json"}
 
         response = requests.post(
@@ -165,7 +164,5 @@ class VirtualMachineCLI(CLIParser):
         return VirtualMachine(
             args.name,
             notification_emails=args.notification_emails,
-            app_path=args.app_path,
-            json_listing_config=args.config_json,
             config_yaml=args.config_yml,
         ).publish()

--- a/tests/cli_groups_tests.py
+++ b/tests/cli_groups_tests.py
@@ -114,8 +114,7 @@ def _publish_command_args(config_yml, subgroup):
         "command": "publish",
         "name": f"test_{subgroup}",
         "config_yml": config_yml,
-        "notification_emails": "dcibs@microsoft.com",
-        "app_path": APP_PATH,
+        "notification_emails": "dcibs@microsoft.com"
     }
     return input_args
 
@@ -183,11 +182,9 @@ def vm_list_command(config_yml, monkeypatch, capsys):
     return args_test(monkeypatch, args, capsys)
 
 
-def vm_publish_command(config_yml, json_config, monkeypatch, capsys):
+def vm_publish_command(config_yml, name, monkeypatch, capsys):
     args = _publish_command_args(config_yml, subgroup="vm")
-    args["name"] = "test-vm"
-    args["config_json"] = json_config
-    args["app_path"] = APP_PATH
+    args["name"] = name
     return args_test(monkeypatch, args, capsys)
 
 

--- a/tests/cli_groups_tests.py
+++ b/tests/cli_groups_tests.py
@@ -114,7 +114,7 @@ def _publish_command_args(config_yml, subgroup):
         "command": "publish",
         "name": f"test_{subgroup}",
         "config_yml": config_yml,
-        "notification_emails": "dcibs@microsoft.com"
+        "notification_emails": "dcibs@microsoft.com",
     }
     return input_args
 

--- a/tests/sample_app/config_invalid_publisher.yml
+++ b/tests/sample_app/config_invalid_publisher.yml
@@ -1,0 +1,5 @@
+tenant_id: "ABC123"
+azure_preview_subscription: "ABC123"
+aad_id: "ABC123"
+aad_secret: "ABC123"
+access_id: "ABC123"

--- a/tests/test_cli_group_vm.py
+++ b/tests/test_cli_group_vm.py
@@ -270,11 +270,8 @@ def test_vm_list_invalid_auth_details(config_yml, monkeypatch, capsys):
 @pytest.mark.integration
 @pytest.mark.skip(reason="Need to determine how to clean up test safely")
 def test_vm_publish_success(config_yml, vm_offer_setup_teardown, monkeypatch, capsys):
-    # Need to determine how to clean up tests so that it cancels the publish
-    # operation and can then delete the offer
-    json_listing_config = "vm_config.json"
-
-    offer_response = vm_publish_command(config_yml, json_listing_config, monkeypatch, capsys)
+    name = "test-vm"
+    offer_response = vm_publish_command(config_yml, name, monkeypatch, capsys)
 
     print(offer_response)
 
@@ -282,11 +279,13 @@ def test_vm_publish_success(config_yml, vm_offer_setup_teardown, monkeypatch, ca
 @pytest.mark.integration
 @pytest.mark.xfail(raises=ValueError)
 def test_vm_publish_missing_publisher_id(config_yml, monkeypatch, capsys):
-    # Invalid JSON config with missing publisher ID
-    json_listing_config = "vm_config_missing_publisher_id.json"
+    # Invalid config yaml file missing publisher ID
+    config_yml = "tests/sample_app/config_invalid_publisher.yml"
+
+    name = "test-vm"
 
     # Expecting a Value error when unable to access Publisher ID
-    vm_publish_command(config_yml, json_listing_config, monkeypatch, capsys)
+    vm_publish_command(config_yml, name, monkeypatch, capsys)
 
 
 @pytest.mark.integration
@@ -295,12 +294,11 @@ def test_vm_publish_invalid_auth_details(config_yml, monkeypatch, capsys):
     # Invalid config yaml file using incorrect client ID & secret
     config_yml = "tests/sample_app/config_invalid.yml"
 
-    # Valid JSON configuration file
-    json_listing_config = "vm_config.json"
+    name = "test-vm"
 
     # Expecting a failure from the Authentication Context package as the
     # auth token is unable to be retreived
-    vm_publish_command(config_yml, json_listing_config, monkeypatch, capsys)
+    vm_publish_command(config_yml, name, monkeypatch, capsys)
 
 
 @pytest.mark.integration
@@ -309,22 +307,14 @@ def test_vm_publish_offer_doesnot_exist(config_yml, monkeypatch, capsys):
     # Invalid configuration to show an offer that doesnt exist
     json_listing_config = "vm_config_uncreated_offer.json"
 
+    name = "test-nevercreated"
+
     # Confirm that the offer does not exist
     with pytest.raises(LookupError):
         vm_show_command(config_yml, json_listing_config, monkeypatch, capsys)
 
     # Expecting a failure as the offer does not exist
-    vm_publish_command(config_yml, json_listing_config, monkeypatch, capsys)
-
-
-@pytest.mark.integration
-@pytest.mark.xfail(raises=ConnectionError)
-def test_vm_publish_invalid_offer(config_yml, monkeypatch, capsys):
-    # All of the required config is not set, so unable to publish offer
-    json_listing_config = "vm_invalid_config.json"
-
-    # Expecting a failure as the offer isnt fully configured
-    vm_publish_command(config_yml, json_listing_config, monkeypatch, capsys)
+    vm_publish_command(config_yml, name, monkeypatch, capsys)
 
 
 @pytest.mark.integration

--- a/tests/test_cli_groups_mock.py
+++ b/tests/test_cli_groups_mock.py
@@ -352,7 +352,7 @@ def test_vm_list_invalid_auth_details_mock(config_yml, monkeypatch, capsys):
 
 
 def test_vm_publish_success_mock(config_yml, monkeypatch, capsys):
-    vm_config_json = "vm_config.json"
+    name = "test-vm"
 
     # Mock authorization token retreival
     def mock_get_auth(self, resource, client_id, client_secret):
@@ -373,7 +373,7 @@ def test_vm_publish_success_mock(config_yml, monkeypatch, capsys):
 
     monkeypatch.setattr(requests, "post", mock_publish_offer)
 
-    response = cli_tests.vm_publish_command(config_yml, vm_config_json, monkeypatch, capsys)
+    response = cli_tests.vm_publish_command(config_yml, name, monkeypatch, capsys)
 
     assert json.loads(response) == True
 
@@ -381,11 +381,13 @@ def test_vm_publish_success_mock(config_yml, monkeypatch, capsys):
 @pytest.mark.integration
 @pytest.mark.xfail(raises=ValueError)
 def test_vm_publish_missing_publisher_id_mock(config_yml, monkeypatch, capsys):
-    # Invalid JSON config with missing publisher ID
-    vm_config_json = "vm_config_missing_publisher_id.json"
+    # Invalid config yaml file missing publisher ID
+    config_yml = "tests/sample_app/config_invalid_publisher.yml"
+
+    name = "test-vm"
 
     # No mocks required because it does not hit any APIs
-    cli_tests.vm_publish_command(config_yml, vm_config_json, monkeypatch, capsys)
+    cli_tests.vm_publish_command(config_yml, name, monkeypatch, capsys)
 
 
 @pytest.mark.integration
@@ -394,8 +396,7 @@ def test_vm_publish_invalid_auth_details_mock(config_yml, monkeypatch, capsys):
     # Invalid config yaml file using incorrect client ID & secret
     config_yml = "tests/sample_app/config_invalid.yml"
 
-    # Valid JSON configuration file
-    json_listing_config = "vm_config.json"
+    name = "test-vm"
 
     # Mock authorization token retreival to return an error
     def mock_get_auth(self, resource, client_id, client_secret):
@@ -403,14 +404,13 @@ def test_vm_publish_invalid_auth_details_mock(config_yml, monkeypatch, capsys):
 
     monkeypatch.setattr(AuthenticationContext, "acquire_token_with_client_credentials", mock_get_auth)
 
-    cli_tests.vm_publish_command(config_yml, json_listing_config, monkeypatch, capsys)
+    cli_tests.vm_publish_command(config_yml, name, monkeypatch, capsys)
 
 
 @pytest.mark.integration
 @pytest.mark.xfail(raises=ConnectionError)
 def test_vm_publish_offer_does_not_exist_mock(config_yml, monkeypatch, capsys):
-    # Invalid configuration to show an offer that doesnt exist
-    vm_config_json = "vm_config_uncreated_offer.json"
+    name = "test-nevercreated"
 
     # Mock authorization token retreival
     def mock_get_auth(self, resource, client_id, client_secret):
@@ -436,14 +436,13 @@ def test_vm_publish_offer_does_not_exist_mock(config_yml, monkeypatch, capsys):
     monkeypatch.setattr(requests, "post", mock_publish_offer)
 
     # Expecting a failure as the offer does not exist
-    cli_tests.vm_publish_command(config_yml, vm_config_json, monkeypatch, capsys)
+    cli_tests.vm_publish_command(config_yml, name, monkeypatch, capsys)
 
 
 @pytest.mark.integration
 @pytest.mark.xfail(raises=ConnectionError)
 def test_vm_publish_invalid_offer_mock(config_yml, monkeypatch, capsys):
-    # Invalid configuration to show an offer that doesnt exist
-    vm_config_json = "vm_config.json"
+    name = "test-invalid"
 
     # Mock authorization token retreival
     def mock_get_auth(self, resource, client_id, client_secret):
@@ -469,7 +468,7 @@ def test_vm_publish_invalid_offer_mock(config_yml, monkeypatch, capsys):
     monkeypatch.setattr(requests, "post", mock_publish_offer)
 
     # Expecting a failure as the offer does not exist
-    cli_tests.vm_publish_command(config_yml, vm_config_json, monkeypatch, capsys)
+    cli_tests.vm_publish_command(config_yml, name, monkeypatch, capsys)
 
 
 def test_vm_delete_success_mock(config_yml, monkeypatch, capsys):


### PR DESCRIPTION
Simplifying the VM publish command so that it's more consistent with the other offer types. Rather than looking up the offer ID and publisherId in the listing config, this:
- uses the `name` arg that's already passed in for the offer ID
- uses the `publisherId` that's in the config.yml