### PR TITLE
fix: Resolve issues uploading managed app tech config

### DIFF
--- a/azureiai/managed_apps/confs/variant/package.py
+++ b/azureiai/managed_apps/confs/variant/package.py
@@ -76,6 +76,7 @@ class Package(VariantPlanConfiguration):
         allowed_customer_actions: list = None,
         allowed_data_actions: list = None,
         json_config: dict = None,
+        plan_name: str = None,
     ):
         """
         Set Package Configuration
@@ -146,7 +147,7 @@ class Package(VariantPlanConfiguration):
                 "ID": settings_id,
             }
         else:
-            plan_config = self._load_plan_config(json_config)
+            plan_config = self._load_plan_config(json_config, plan_name)
             tenant_id = os.getenv(TENANT_ID, plan_config["technical_configuration"]["tenant_id"])
             access_id = os.getenv(ACCESS_ID, plan_config["technical_configuration"]["authorizations"][0]["id"])
             role = os.getenv("ACCESS_OWNER", plan_config["technical_configuration"]["authorizations"][0]["role"])
@@ -183,10 +184,12 @@ class Package(VariantPlanConfiguration):
         return response
 
     @staticmethod
-    def _load_plan_config(json_config: dict):
+    def _load_plan_config(json_config: dict, plan_name=None):
         plan_overview = json_config["plan_overview"]
         if isinstance(plan_overview, list):
             return plan_overview[0]
+        if plan_name:
+            return plan_overview[plan_name]
         return plan_overview[next(iter(plan_overview))]
 
     def _check_upload(self, post_response):

--- a/azureiai/managed_apps/managed_app.py
+++ b/azureiai/managed_apps/managed_app.py
@@ -278,10 +278,12 @@ class ManagedApplication(Offer):
             raise RetryException() from api_expection
 
     @staticmethod
-    def _load_plan_config(json_config):
+    def _load_plan_config(json_config, plan_name=None):
         plan_overview = json_config["plan_overview"]
         if isinstance(plan_overview, list):
             return plan_overview[0]
+        if plan_name:
+            return plan_overview[plan_name]
         return plan_overview[next(iter(plan_overview))]
 
     def _set_plan_listing(self, json_config):

--- a/azureiai/partner_center/plan.py
+++ b/azureiai/partner_center/plan.py
@@ -191,6 +191,7 @@ class Plan(Submission):
                     allowed_customer_actions=allowed_customer_actions,
                     allowed_data_actions=allowed_data_actions,
                     json_config=json_config,
+                    plan_name=self.plan_name,
                 )
             if self.subtype == "st":
                 package = Package(


### PR DESCRIPTION
When adding in #185 - the plan config changes did not span the `package` class which is referenced when configuring the Technical Configuration for a Managed Application offer.