### PR TITLE
fix: Resolve bug related to offer ID and display name

### DIFF
--- a/Partner_Ingestion_SwaggerDocument.json
+++ b/Partner_Ingestion_SwaggerDocument.json
@@ -7021,6 +7021,12 @@
                   "AzureDynamics365BusinessCentral"
                 ],
                 "type": "string"
+              },
+              "externalIDs"        : {
+                "type" : "array",
+                "items": {
+                  "$ref": "#/components/schemas/Microsoft.Ingestion.Api.Models.Common.TypeValuePair"
+                }
               }
             }
           }

--- a/azureiai/partner_center/offers/virtual_machine.py
+++ b/azureiai/partner_center/offers/virtual_machine.py
@@ -66,17 +66,6 @@ class VirtualMachine(Submission):
             self._raise_connection_error(response)
         return response.json()
 
-    def show(self):
-        """Show details of an Virtual Machine offer"""
-        filter_name = "ExternalIDs/Any(i:i/Type eq 'AzureOfferId' and i/Value eq '" + self.name + "')"
-        api_response = self._apis["product"].products_get(authorization=self.get_auth(), filter=filter_name)
-        submissions = api_response.to_dict()
-        for submission in submissions["value"]:
-            if submission["external_i_ds"][0]["value"] == self.name:
-                self._ids["product_id"] = submission["id"]
-                return submission
-        raise LookupError(f"{self.resource_type} with this name not found: {self.name}")
-
     def list_contents(self) -> dict:
         """list only the Virtual Machine offers"""
         with open(self.config_yaml, encoding="utf8") as file:

--- a/azureiai/partner_center/offers/virtual_machine.py
+++ b/azureiai/partner_center/offers/virtual_machine.py
@@ -66,6 +66,17 @@ class VirtualMachine(Submission):
             self._raise_connection_error(response)
         return response.json()
 
+    def show(self):
+        """Show details of an Virtual Machine offer"""
+        filter_name = "ExternalIDs/Any(i:i/Type eq 'AzureOfferId' and i/Value eq '" + self.name + "')"
+        api_response = self._apis["product"].products_get(authorization=self.get_auth(), filter=filter_name)
+        submissions = api_response.to_dict()
+        for submission in submissions["value"]:
+            if submission["external_i_ds"][0]["value"] == self.name:
+                self._ids["product_id"] = submission["id"]
+                return submission
+        raise LookupError(f"{self.resource_type} with this name not found: {self.name}")
+
     def list_contents(self) -> dict:
         """list only the Virtual Machine offers"""
         with open(self.config_yaml, encoding="utf8") as file:

--- a/azureiai/partner_center/submission.py
+++ b/azureiai/partner_center/submission.py
@@ -70,7 +70,7 @@ class Submission(Offer):
         api_response = self._apis["product"].products_get(authorization=self.get_auth(), filter=filter_name)
         submissions = api_response.to_dict()
         for submission in submissions["value"]:
-            if submission["external_i_ds"][0]["value"] == self.name:
+            if submission["name"] == self.name:
                 self._ids["product_id"] = submission["id"]
                 return submission
         raise LookupError(f"{self.resource_type} with this name not found: {self.name}")

--- a/azureiai/partner_center/submission.py
+++ b/azureiai/partner_center/submission.py
@@ -70,7 +70,7 @@ class Submission(Offer):
         api_response = self._apis["product"].products_get(authorization=self.get_auth(), filter=filter_name)
         submissions = api_response.to_dict()
         for submission in submissions["value"]:
-            if submission["name"] == self.name:
+            if submission["external_i_ds"][0]["value"] == self.name:
                 self._ids["product_id"] = submission["id"]
                 return submission
         raise LookupError(f"{self.resource_type} with this name not found: {self.name}")

--- a/tests/cli_groups_tests.py
+++ b/tests/cli_groups_tests.py
@@ -462,7 +462,7 @@ def _assert_technical_configuration(offer, json_listing_config):
 
 
 def _assert_vm_show(offer, json_listing_config):
-    assert offer["name"] == json_listing_config["definition"]["displayText"]
+    assert offer["external_i_ds"][0]["value"] == json_listing_config["id"]
     assert offer["id"]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,11 +113,36 @@ def ama_mock(ama_name, monkeypatch):
         response_json = namedtuple("response", ["value", "odata_etag", "id"])(
             *[
                 [
-                    {"resource_type": "AzureThirdPartyVirtualMachine", "name": "test_vm", "id": "abc-123", "external_i_ds": [ { "type": "AzureOfferId", "value": "test_vm" } ]},
-                    {"resource_type": "AzureApplication", "name": "cicd-test", "id": "abc-123", "external_i_ds": [ { "type": "AzureOfferId", "value": "cicd-test" } ]},
-                    {"resource_type": "AzureApplication", "name": "test_ma", "id": "abc-123", "external_i_ds": [ { "type": "AzureOfferId", "value": "test_ma" } ]},
-                    {"resource_type": "AzureApplication", "name": "test_st", "id": "abc-123", "external_i_ds": [ { "type": "AzureOfferId", "value": "test_st" } ]},
-                    {"resource_type": "AzureContainer", "name": "test_co", "id": "abc-123", "external_i_ds": [ { "type": "AzureOfferId", "value": "test_co" } ]},
+                    {
+                        "resource_type": "AzureThirdPartyVirtualMachine",
+                        "name": "test_vm",
+                        "id": "abc-123",
+                        "external_i_ds": [{"type": "AzureOfferId", "value": "test_vm"}],
+                    },
+                    {
+                        "resource_type": "AzureApplication",
+                        "name": "cicd-test",
+                        "id": "abc-123",
+                        "external_i_ds": [{"type": "AzureOfferId", "value": "cicd-test"}],
+                    },
+                    {
+                        "resource_type": "AzureApplication",
+                        "name": "test_ma",
+                        "id": "abc-123",
+                        "external_i_ds": [{"type": "AzureOfferId", "value": "test_ma"}],
+                    },
+                    {
+                        "resource_type": "AzureApplication",
+                        "name": "test_st",
+                        "id": "abc-123",
+                        "external_i_ds": [{"type": "AzureOfferId", "value": "test_st"}],
+                    },
+                    {
+                        "resource_type": "AzureContainer",
+                        "name": "test_co",
+                        "id": "abc-123",
+                        "external_i_ds": [{"type": "AzureOfferId", "value": "test_co"}],
+                    },
                 ],
                 "",
                 "",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,16 +113,11 @@ def ama_mock(ama_name, monkeypatch):
         response_json = namedtuple("response", ["value", "odata_etag", "id"])(
             *[
                 [
-                    {"name": "test_vm", "id": "abc-123", "variant_id": "abcd1324", "current_draft_instance_id": "123"},
-                    {
-                        "name": "cicd-test",
-                        "id": "abc-123",
-                        "variant_id": "abcd1324",
-                        "current_draft_instance_id": "123",
-                    },
-                    {"name": "test_ma", "id": "abc-123", "variant_id": "abcd1324", "current_draft_instance_id": "123"},
-                    {"name": "test_st", "id": "abc-123", "variant_id": "abcd1324", "current_draft_instance_id": "123"},
-                    {"name": "test_co", "id": "abc-123", "variant_id": "abcd1234", "current_draft_instance_id": "123"},
+                    {"resource_type": "AzureThirdPartyVirtualMachine", "name": "test_vm", "id": "abc-123", "external_i_ds": [ { "type": "AzureOfferId", "value": "test_vm" } ]},
+                    {"resource_type": "AzureApplication", "name": "cicd-test", "id": "abc-123", "external_i_ds": [ { "type": "AzureOfferId", "value": "cicd-test" } ]},
+                    {"resource_type": "AzureApplication", "name": "test_ma", "id": "abc-123", "external_i_ds": [ { "type": "AzureOfferId", "value": "test_ma" } ]},
+                    {"resource_type": "AzureApplication", "name": "test_st", "id": "abc-123", "external_i_ds": [ { "type": "AzureOfferId", "value": "test_st" } ]},
+                    {"resource_type": "AzureContainer", "name": "test_co", "id": "abc-123", "external_i_ds": [ { "type": "AzureOfferId", "value": "test_co" } ]},
                 ],
                 "",
                 "",

--- a/tests/sample_app/vm_config.json
+++ b/tests/sample_app/vm_config.json
@@ -7,7 +7,7 @@
       "microsoft-azure-marketplace": 39
   },
   "definition": {
-      "displayText": "test-vm",
+      "displayText": "Contoso Virtual Machine Offer",
       "offer": {
       "microsoft-azure-marketplace.title": "Contoso App",
       "microsoft-azure-marketplace.summary": "Contoso App makes dev ops a breeze",

--- a/tests/test_cli_groups_mock.py
+++ b/tests/test_cli_groups_mock.py
@@ -102,6 +102,7 @@ def test_vm_create_success_mock(config_yml, vm_config_json, monkeypatch, capsys)
 
 @pytest.mark.integration
 @pytest.mark.xfail(raises=NameError)
+@pytest.mark.xfail(raises=SystemExit)
 def test_vm_create_offer_exists_mock(config_yml, monkeypatch, vm_config_json, capsys):
     vm_config_json = "vm_config.json"
 

--- a/tests/test_data/vm_create_valid_response.json
+++ b/tests/test_data/vm_create_valid_response.json
@@ -8,7 +8,7 @@
     "version": 1252868275,
     "id": "test-vm",
     "definition": {
-        "displayText": "test-vm",
+        "displayText": "Contoso Virtual Machine Offer",
         "offer": {
             "microsoft-azure-marketplace.leadDestination": "None",
             "microsoft-azure-marketplace.blobLeadConfiguration": {},

--- a/tests/test_data/vm_list_valid_response.json
+++ b/tests/test_data/vm_list_valid_response.json
@@ -13,7 +13,7 @@
         "version": 0,
         "id": "test-vm",
         "definition": {
-            "displayText": "test-vm"
+            "displayText": "Contoso Virtual Machine Offer"
         },
         "changedTime": "2022-06-02T12:25:56.651"
     },
@@ -35,4 +35,4 @@
         },
         "changedTime": "2022-05-30T06:43:52.062"
     }
-] 
+]

--- a/tests/test_data/vm_show_valid_response.json
+++ b/tests/test_data/vm_show_valid_response.json
@@ -1,15 +1,15 @@
 {
     "value": [
         {
-            "resourceType": "AzureThirdPartyVirtualMachine",
+            "resource_type": "AzureThirdPartyVirtualMachine",
             "name": "test-vm",
-            "externalIDs": [
+            "external_i_ds": [
                 {
                     "type": "AzureOfferId",
                     "value": "test-vm"
                 }
             ],
-            "isModularPublishing": true,
+            "is_modular_publishing": true,
             "id": "abc123"
         }
     ]


### PR DESCRIPTION
There is a bug in the Partner Ingestion Swagger spec where external ids are not an included attribute for an Azure Product. This has led to the CLI not returning the offer ID in the `show` method and only the offer display name.
This was leading to an issue where for the CLI to function as expected, we needed the offer id (GUID) and the display name to be the same, which is an incorrect assumption.
This is no longer an issue now that the Swagger spec has been updated.